### PR TITLE
[Breaking] Add the option to provide a dynamic router

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-- 2.2.0
+- 2.3.0
 deploy:
   provider: rubygems
   api_key:

--- a/lib/chef_deployment_monitor/config.rb
+++ b/lib/chef_deployment_monitor/config.rb
@@ -24,9 +24,11 @@ class Chef
         extend Mixlib::Config
         config_strict_mode true
 
-        default :blacklisted?, Proc.new { |data| false } # rubocop:disable Lint/UnusedBlockArgument:
-        default :marker_file, '/tmp/last_chef_deployment'
-        default :history_file, '/tmp/lasts_chef_deployment'
+        default :blacklisted?, Proc.new { |data| false } # rubocop:disable Lint/UnusedBlockArgument, Lint/AmbiguousBlockAssociation
+        default :route, Proc.new { |data| "" } # rubocop:disable Lint/UnusedBlockArgument, Lint/AmbiguousBlockAssociation
+        default :output_file_directory, '/tmp/'
+        default :marker_file_template, '%slast-deployment.json'
+        default :history_file_template, '%slast-deployments.json'
         default :history_file_size, 1000
         %w(
       mon_file

--- a/lib/chef_deployment_monitor/sinks.rb
+++ b/lib/chef_deployment_monitor/sinks.rb
@@ -9,11 +9,17 @@ class Chef
       end
 
       class MarkerFileSink < Sink
+        attr_reader :file
+
+        def initialize(outfile)
+          @file    = outfile
+        end
+
         # will modify the marker file
         # last write data of marker file will be within 5 seconds
         # of last deployement
         def receive(data)
-          File.open(Monitor::Config[:marker_file], 'w+') do |f|
+          File.open(file, 'w+') do |f|
             f.write(data.to_json)
           end
         end
@@ -23,10 +29,10 @@ class Chef
 
         attr_reader :file
 
-        def initialize
-          @file    = Monitor::Config[:history_file]
+        def initialize(outfile)
+          @file    = outfile
           @history = if File.exist?(file)
-                       JSON.parse(File.read(file)) rescue []
+                       JSON.parse(File.read(file)) rescue [] # rubocop:disable Lint/RescueWithoutErrorClass
                      else
                        []
                      end

--- a/lib/chef_deployment_monitor/version.rb
+++ b/lib/chef_deployment_monitor/version.rb
@@ -18,7 +18,7 @@
 class Chef
   class Deployment
     class Monitor
-      VERSION = '1.1.3'
+      VERSION = '1.1.4'
       MAJOR, MINOR, TINY = VERSION.split('.')
     end
   end


### PR DESCRIPTION
In order to support splitting jobs that modify different elements of the
Chef server (so, for example, deploying normal roles, etc. in a
different process to policyfiles) we add a router that can update files
with a prefix root in an output directory.