### PR TITLE
Fix date parsing for recent chef server versions

### DIFF
--- a/lib/chef_deployment_monitor/logmon.rb
+++ b/lib/chef_deployment_monitor/logmon.rb
@@ -61,7 +61,7 @@ class Chef
         def format(data)
           # convert to timestamp
           data_dup = data.dup
-          date_format = data['time'].index('/') ? '%d/%b/%C:%T %z' : '%Y-%m-%dT%H:%M:%S%z'
+          date_format = data['time'].index('/') ? '%d/%b/%C:%T %z' : '%FT%T%:z'
           data_dup['time'] = DateTime.strptime(data['time'], date_format).to_time.to_i
           data_dup['server'] = data['server'].strip
           data_dup

--- a/lib/chef_deployment_monitor/logmon.rb
+++ b/lib/chef_deployment_monitor/logmon.rb
@@ -61,7 +61,8 @@ class Chef
         def format(data)
           # convert to timestamp
           data_dup = data.dup
-          data_dup['time'] = DateTime.strptime(data['time'], '%d/%b/%C:%T %z').to_time.to_i
+          date_format = data['time'].index('/') ? '%d/%b/%C:%T %z' : '%Y-%m-%dT%H:%M:%S%z'
+          data_dup['time'] = DateTime.strptime(data['time'], date_format).to_time.to_i
           data_dup['server'] = data['server'].strip
           data_dup
         end


### PR DESCRIPTION
In recent chef server versions (at least v14), the nginx default time format is "time_iso8601".  This patch adds a naive test to distinguish old & recent date formats and parse them from nginx logs We can't simply use something like DateTime.parse as old date format is not recognized.